### PR TITLE
Improve compatibility with 0.28

### DIFF
--- a/Sources/PocketBase/Auth/AuthMethods.swift
+++ b/Sources/PocketBase/Auth/AuthMethods.swift
@@ -8,5 +8,7 @@
 public struct AuthMethods: Codable, Sendable, Equatable {
     public var usernamePassword: Bool
     public var emailPassword: Bool
-    public var authProviders: [OAuthProvider]
+    public var oauth2: Oauth2Methods
 }
+
+

--- a/Sources/PocketBase/Auth/Oauth2Methods.swift
+++ b/Sources/PocketBase/Auth/Oauth2Methods.swift
@@ -1,0 +1,12 @@
+//
+//  Oauth2Methods.swift
+//  PocketBase
+//
+//  Created by Konstantin Gerry on 01/06/2025.
+//
+
+
+public struct Oauth2Methods: Codable, Sendable, Equatable {
+    public var providers: [OAuthProvider]
+    public var enabled: Bool
+}

--- a/Sources/PocketBase/Realtime/Realtime+Events.swift
+++ b/Sources/PocketBase/Realtime/Realtime+Events.swift
@@ -10,12 +10,12 @@ import Foundation
 public protocol Event: Sendable, Equatable {
     associatedtype Value = Decodable
     var id: String? { get }
-    var value: Value { get }
+    var record: Value { get }
 }
 
 public struct RawRecordEvent: Event {
     public var id: String?
-    public var value: String
+    public var record: String
 }
 
 public protocol DecodableEvent: Event, Decodable {}
@@ -23,7 +23,7 @@ public protocol DecodableEvent: Event, Decodable {}
 public struct RecordEvent<Record: BaseRecord>: DecodableEvent {
     public var id: String?
     public var action: Action
-    public var value: Record
+    public var record: Record
     
     public enum Action: String, Decodable, Sendable {
         case create

--- a/Sources/PocketBase/Realtime/Realtime.swift
+++ b/Sources/PocketBase/Realtime/Realtime.swift
@@ -116,7 +116,7 @@ extension Realtime: EventHandler {
             }
             let rawEvent = RawRecordEvent(
                 id: messageEvent.lastEventId,
-                value: message
+                record: message
             )
             await subscription.channel.send(rawEvent)
         }

--- a/Sources/PocketBase/Realtime/RecordCollection+Subscribe.swift
+++ b/Sources/PocketBase/Realtime/RecordCollection+Subscribe.swift
@@ -20,7 +20,7 @@ extension RecordCollection where T: BaseRecord {
                         Self.logger.error("Event is not raw record event")
                         continue
                     }
-                    for line in rawEvent.value.components(separatedBy: "\n") {
+                    for line in rawEvent.record.components(separatedBy: "\n") {
                         do {
                             let event = try PocketBase.decoder.decode(
                                 RecordEvent<T>.self,

--- a/Sources/PocketBaseUI/Auth/SignedOutView.swift
+++ b/Sources/PocketBaseUI/Auth/SignedOutView.swift
@@ -95,9 +95,9 @@ public struct SignedOutView<T: AuthRecord>: View, HasLogger {
                                 )
                             }
                         }
-                        if !authMethods.authProviders.isEmpty {
+                        if !authMethods.oauth2.providers.isEmpty {
                             Section {
-                                ForEach(authMethods.authProviders) { provider in
+                                ForEach(authMethods.oauth2.providers) { provider in
                                     SignUpButton<T>(
                                         newUser,
                                         collection: collection,
@@ -123,9 +123,9 @@ public struct SignedOutView<T: AuthRecord>: View, HasLogger {
                             }
                         }
                         
-                        if !authMethods.authProviders.isEmpty {
+                        if !authMethods.oauth2.providers.isEmpty {
                             Section {
-                                ForEach(authMethods.authProviders) { provider in
+                                ForEach(authMethods.oauth2.providers) { provider in
                                     LoginButton<T>(
                                         collection: collection,
                                         authState: $authState,

--- a/Sources/PocketBaseUI/Collections/RealtimeQuery.swift
+++ b/Sources/PocketBaseUI/Collections/RealtimeQuery.swift
@@ -71,7 +71,7 @@ public struct RealtimeQuery<T: BaseRecord>: DynamicProperty {
         }
         let events = try await collection.events()
         for await event in events {
-            let record = event.value
+            let record = event.record
             switch event.action {
             case .create:
                 insert(record)

--- a/Tests/PocketBaseIntegrationTests/IntegrationTests.swift
+++ b/Tests/PocketBaseIntegrationTests/IntegrationTests.swift
@@ -68,6 +68,12 @@ func happyPath() async throws {
         try await users.authRefresh()
     })
     
+    // list authentication methods
+    
+    let methods = try await users.listAuthMethods()
+    
+    #expect(methods.emailPassword)
+    
     // Create a new user
     let password = "Test1234%"
     var user = try await users.create(

--- a/Tests/PocketBaseTests/Auth/AuthMethodsTests.swift
+++ b/Tests/PocketBaseTests/Auth/AuthMethodsTests.swift
@@ -16,11 +16,11 @@ struct AuthMethodsTests {
         let methods = AuthMethods(
             usernamePassword: true,
             emailPassword: true,
-            authProviders: []
+            oauth2: Oauth2Methods(providers: [], enabled: false)
         )
         #expect(methods.usernamePassword)
         #expect(methods.emailPassword)
-        #expect(methods.authProviders.isEmpty)
+        #expect(methods.oauth2.providers.isEmpty)
     }
 
 }

--- a/Tests/PocketBaseTests/Auth/RecordCollectionTests+Auth.swift
+++ b/Tests/PocketBaseTests/Auth/RecordCollectionTests+Auth.swift
@@ -299,7 +299,7 @@ extension RecordCollectionTests {
             let methods = AuthMethods(
                 usernamePassword: true,
                 emailPassword: true,
-                authProviders: []
+                oauth2: Oauth2Methods(providers: [], enabled: false)
             )
             let environment = PocketBase.TestEnvironment(
                 baseURL: baseURL,


### PR DESCRIPTION
This PR adapts several types involved in the login process to make the package compatible with the current 0.28 "out of box" schema:

- Checking for supported auth methods, the package will now use the the `oauth` field. The `authProviders` field has been deprecated and now returns `null`.
- Realtime events now have a `record` field instead of a `value` field.