### PR TITLE
Fix auth UI bugs and improve decoding resilience

### DIFF
--- a/Sources/PocketBaseMacros/RecordCollectionMacro.swift
+++ b/Sources/PocketBaseMacros/RecordCollectionMacro.swift
@@ -25,6 +25,9 @@ extension RecordCollectionMacro {
     ) throws -> [ExtensionDeclSyntax] {
         [
             ExtensionDeclSyntax(
+                modifiers: DeclModifierListSyntax {
+                    DeclModifierSyntax(name: .keyword(.nonisolated))
+                },
                 extendedType: type,
                 inheritanceClause: InheritanceClauseSyntax {
                     for type in protocols {
@@ -318,10 +321,10 @@ extension RecordCollectionMacro {
 
         if isAuthCollection(node) {
             body.append("// Auth Collection Fields")
-            body.append("username = try container.decode(String.self, forKey: .username)")
+            body.append("username = try container.decodeIfPresent(String.self, forKey: .username) ?? \"\"")
             body.append("email = try container.decodeIfPresent(String.self, forKey: .email)")
-            body.append("verified = try container.decode(Bool.self, forKey: .verified)")
-            body.append("emailVisibility = try container.decode(Bool.self, forKey: .emailVisibility)")
+            body.append("verified = try container.decodeIfPresent(Bool.self, forKey: .verified) ?? false")
+            body.append("emailVisibility = try container.decodeIfPresent(Bool.self, forKey: .emailVisibility) ?? false")
         }
 
         if !variables.isEmpty {
@@ -378,7 +381,7 @@ extension RecordCollectionMacro {
                     }
                 ),
                 effectSpecifiers: FunctionEffectSpecifiersSyntax(
-                    throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+                    throwsSpecifier: .keyword(.throws)
                 )
             )
         ) {
@@ -782,7 +785,7 @@ extension RecordCollectionMacro {
                     }
                 ),
                 effectSpecifiers: FunctionEffectSpecifiersSyntax(
-                    throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+                    throwsSpecifier: .keyword(.throws)
                 )
             )
         ) {

--- a/Sources/PocketBaseUI/Auth/CreateUser.swift
+++ b/Sources/PocketBaseUI/Auth/CreateUser.swift
@@ -7,7 +7,8 @@
 
 import PocketBase
 
-/// A callback type that takes a username and password and returns a new `AuthRecord` instance.
+/// A callback type that takes an email and username, and returns a new `AuthRecord` instance.
+/// The password is handled separately by the collection's create method.
 public typealias CreateUser<T: AuthRecord> = (
     _ username: String,
     _ email: String

--- a/Sources/PocketBaseUI/Auth/LoginButton.swift
+++ b/Sources/PocketBaseUI/Auth/LoginButton.swift
@@ -33,7 +33,9 @@ public struct LoginButton<T: AuthRecord>: View, HasLogger {
                             identity,
                             password: password
                         )
-                        authState = .signedIn
+                        await MainActor.run {
+                            authState = .signedIn
+                        }
                     case .oauth:
                         fatalError("Not implemented")
                     }

--- a/Sources/PocketBaseUI/Auth/SignUpButton.swift
+++ b/Sources/PocketBaseUI/Auth/SignUpButton.swift
@@ -13,52 +13,81 @@ public struct SignUpButton<T: AuthRecord>: View, HasLogger {
     let newRecord: CreateUser<T>
     let collection: RecordCollection<T>
     @Binding private var authState: AuthState
-    private var strategy: RecordCollection<T>.AuthMethod
+    private let email: String
+    private let username: String
+    private let password: String
+    private let oauthProvider: OAuthProvider?
 
+    /// Initialize for email/password sign up
     public init(
         _ newRecord: @escaping CreateUser<T>,
         collection: RecordCollection<T>,
         authState: Binding<AuthState>,
-        strategy: RecordCollection<T>.AuthMethod
+        email: String,
+        username: String,
+        password: String
     ) {
         self.newRecord = newRecord
         self.collection = collection
         _authState = authState
-        self.strategy = strategy
+        self.email = email
+        self.username = username
+        self.password = password
+        self.oauthProvider = nil
     }
-    
+
+    /// Initialize for OAuth sign up
+    public init(
+        _ newRecord: @escaping CreateUser<T>,
+        collection: RecordCollection<T>,
+        authState: Binding<AuthState>,
+        provider: OAuthProvider
+    ) {
+        self.newRecord = newRecord
+        self.collection = collection
+        _authState = authState
+        self.email = ""
+        self.username = ""
+        self.password = ""
+        self.oauthProvider = provider
+    }
+
     func signUp() {
         Task {
             do {
-                switch strategy {
-                case .identity(let identity, let password):
-                    let newRecord = try await newRecord(identity, password)
-                    try await collection.create(
-                        newRecord,
-                        password: password,
-                        passwordConfirm: password
-                    )
-                    try await collection.authWithPassword(
-                        identity,
-                        password: password
-                    )
-                case .oauth:
-                    Self.logger.fault("OAuth is not implemented yet")
+                if let provider = oauthProvider {
+                    // OAuth sign up - not implemented yet
+                    Self.logger.fault("OAuth is not implemented yet for provider: \(provider.name)")
+                    return
                 }
-                authState = .signedIn
+
+                let record = try await newRecord(username, email)
+                try await collection.create(
+                    record,
+                    password: password,
+                    passwordConfirm: password
+                )
+                // Use email or username as identity for login
+                let identity = email.isEmpty ? username : email
+                try await collection.authWithPassword(
+                    identity,
+                    password: password
+                )
+                await MainActor.run {
+                    authState = .signedIn
+                }
             } catch {
                 Self.logger.error("Failed to sign up: \(error)")
             }
         }
     }
-    
+
     public var body: some View {
         Button(action: signUp) {
-            switch strategy {
-            case .identity:
-                Label("Sign Up", systemImage: "person.crop.circle.fill")
-            case .oauth(let provider):
+            if let provider = oauthProvider {
                 Label("Sign Up with \(provider.name)", systemImage: provider.name)
+            } else {
+                Label("Sign Up", systemImage: "person.crop.circle.fill")
             }
         }
     }

--- a/Sources/PocketBaseUI/Auth/SignedOutView.swift
+++ b/Sources/PocketBaseUI/Auth/SignedOutView.swift
@@ -88,10 +88,9 @@ public struct SignedOutView<T: AuthRecord>: View, HasLogger {
                                     newUser,
                                     collection: collection,
                                     authState: $authState,
-                                    strategy: .identity(
-                                        authMethods.emailPassword ? newEmail : newUsername,
-                                        password: password
-                                    )
+                                    email: newEmail,
+                                    username: newUsername,
+                                    password: password
                                 )
                             }
                         }
@@ -102,7 +101,7 @@ public struct SignedOutView<T: AuthRecord>: View, HasLogger {
                                         newUser,
                                         collection: collection,
                                         authState: $authState,
-                                        strategy: .oauth(provider)
+                                        provider: provider
                                     )
                                 }
                             }
@@ -111,7 +110,13 @@ public struct SignedOutView<T: AuthRecord>: View, HasLogger {
                         if authMethods.emailPassword || authMethods.usernamePassword {
                             Section("Identity") {
                                 TextField(identityLabel, text: $loginIdentity)
+                                    .textContentType(.username)
+                                    .autocorrectionDisabled()
+                                    #if os(iOS)
+                                    .textInputAutocapitalization(.never)
+                                    #endif
                                 SecureField("Password", text: $password)
+                                    .textContentType(.password)
                             }
                             Section {
                                 LoginButton<T>(


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the authentication UI that prevented login and signup from working correctly.

### Fixes

- **Main actor isolation**: Wrapped `authState` updates in `MainActor.run` in both `LoginButton` and `SignUpButton` to prevent Swift 6 concurrency issues
- **Parameter handling**: Fixed `SignUpButton` to properly pass `email` and `username` as separate parameters instead of mixing them with `password`
- **CreateUser callback**: Updated typedef to use correct parameter names (`username`, `email`)
- **Text content type hints**: Added `.textContentType` modifiers to login form fields for better autofill support
- **Decoding resilience**: Auth fields (`username`, `verified`, `emailVisibility`) now use `decodeIfPresent` with defaults since PocketBase omits these when empty/null

### Before

- Login button would crash or fail silently due to main actor isolation
- Signup would send password as email field, causing validation errors
- Decoding would fail when PocketBase returned responses without `username` field

### After

- Login and signup work correctly
- Proper field mapping for user creation
- Robust decoding that handles missing optional fields

## Test plan

- [x] Test login with existing user
- [x] Test signup with new user
- [x] Verify no crashes on button tap
- [x] Check that user record is created with correct email/username

🤖 Generated with [Claude Code](https://claude.com/claude-code)