### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
 
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/briannadoubt/PocketBase/security/code-scanning/1](https://github.com/briannadoubt/PocketBase/security/code-scanning/1)

The best way to fix this problem is to add a `permissions:` block with the strictest necessary permissions. Since this workflow only checks out code and runs builds/tests, it only needs to read the repository contents. This can be achieved by inserting `permissions: contents: read` at the top of the workflow file (just after the `name:`), or at the job level; the root-level way is normally preferred for workflows that only need that for all jobs.

**Steps:**
- Insert a `permissions:` block after the `name:` block (line 4), so that it applies to all jobs within the workflow.
- The block should read:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or additional logic are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
