### PR TITLE
Optimize CodeQL workflow triggers and caching

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,13 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - "**/*.md"
+      - "Documentation/**"
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
 
@@ -16,6 +21,7 @@ jobs:
   analyze:
     name: Analyze Swift
     runs-on: macos-26
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-codeql') }}
 
     permissions:
       security-events: write
@@ -37,6 +43,17 @@ jobs:
       with:
         languages: swift
         build-mode: manual
+
+    - name: Cache SwiftPM artifacts
+      uses: actions/cache@v4
+      with:
+        path: |
+          .build
+          ~/.swiftpm
+          ~/Library/Caches/org.swift.swiftpm
+        key: ${{ runner.os }}-swiftpm-codeql-${{ hashFiles('Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-swiftpm-codeql-
 
     - name: Build Swift Package
       run: |


### PR DESCRIPTION
## Summary
- add SwiftPM caching to CodeQL workflow to reduce repeated build time
- keep CodeQL default coverage on pushes to main and weekly scheduled runs
- make PR CodeQL runs opt-in via label 'run-codeql'
- add docs-only PR skip rules for markdown and Documentation changes
- add manual trigger support with workflow_dispatch

## Why
CodeQL on Swift is expensive and can take a long time on PRs. This keeps baseline security scanning while reducing unnecessary PR latency.

## Validation
- workflow file updated and pushed
